### PR TITLE
updating munki to latest version to avoid SDK errors upon compilation

### DIFF
--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -40,7 +40,7 @@ srcIcon = 'AppIcon.icns'
 postinstall_script = 'postinstall_script'
 
 # Git release tag (leave empty for latest build)
-tag = 'v2.2.4'
+tag = 'v2.8.2'
 
 ### Probably don't need to edit below this line
 


### PR DESCRIPTION
Current version produces errors when compiling in 10.11/10.12 because the osx 10.8 sdk is no longer included (and the process for installing it is awful).
