### PR TITLE
Add -c and -d options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The ```--icon-file``` option allows you to specify the path to an icon to replac
 
 To download a specific tag of munki use the ```--munki-release``` option. If this is set to e.g. ```v2.8.2``` munki_rebrand will switch to this release for the building of your customized pkg. See the [Munki releases page](https://github.com/munki/munki/releases) for details of release tags. If this is not set, munki_rebrand will use the latest, bleeding-edge Munki code from Github. To specify the output filename of your custom pkg use ```--output-file```. For example, if you set this to ```"Amazing_Software_Center"``` your output file will be renamed from something like ```munkitools-2.8.2553.pkg``` to ```Amazing_Software_Center-2.8.2553.pkg```
 
+To use a local copy of munki use the ```--local-code``` option and specify a path. This will skip the git clone entirely.
+
 For usage help please see ```sudo ./munki_rebrand.py --help```
 
 ## Notes
@@ -22,4 +24,3 @@ For usage help please see ```sudo ./munki_rebrand.py --help```
 ## To-do
 * Enable the splitting of the distribution pkg into its component pkgs so that the user can decide which to upgrade (perhaps they do not want to upgrade the launchd package if not necessary and can therefore avoid a reboot).
 * munkiimport the resulting pkg(s)?
-

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To download a specific tag of munki use the ```--munki-release``` option. If thi
 
 To use a local copy of munki use the ```--local-code``` option and specify a path. This will skip the git clone entirely.
 
+To use the new DEP package tool, use the ```--dep``` option.
+
 For usage help please see ```sudo ./munki_rebrand.py --help```
 
 ## Notes

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -195,6 +195,7 @@ def main():
             sys.exit(1)
 
     if args.local_code:
+        print 'Using local munki code'
         copy_tree(args.local_code, tmp_dir)
     else:
         # Clone git repo

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -38,8 +38,6 @@ import atexit
 
 MUNKI_GITHUB = 'https://github.com/munki/munki'
 
-MUNKI_MAKESCRIPT = 'code/tools/make_munki_mpkg.sh'
-
 APPNAME_ORIG = 'Managed Software Center'
 
 APPNAME_ORIG_LOCALIZED = {
@@ -258,6 +256,8 @@ def main():
         copyfile(args.postinstall, dest)
         st = stat(dest)
         chmod(dest, (st.st_mode | 0111))
+
+    MUNKI_MAKESCRIPT = 'code/tools/make_munki_mpkg.sh'
 
     # Run the munki build script on the customized files
     print "Building customized Munki..."

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -130,8 +130,7 @@ def convert_to_icns(png, verbose=False):
                '--out', join(iconset, 'icon_%s.png' % suffix)]
         run_cmd(cmd, verbose=verbose)
     icns = join(tmp_dir, 'AppIcns.icns')
-    cmd = ['iconutil', '-c', 'icns', iconset,
-            '-o', icns]
+    cmd = ['iconutil', '-c', 'icns', iconset, '-o', icns]
     run_cmd(cmd, verbose=verbose)
     return icns
 
@@ -142,11 +141,11 @@ def main():
               "munki installer pkg!"
         sys.exit(1)
 
-    p = argparse.ArgumentParser(description="Rebrands Munki's Managed Software "
-                                "Center - gives the app a new name in Finder, "
-                                "and can also modify its icon. N.B. You will "
-                                "need Xcode and its command-line tools installed "
-                                "to run this script successfully.")
+    p = argparse.ArgumentParser(description="Rebrands Munki's Managed Software"
+                                " Center - gives the app a new name in Finder,"
+                                " and can also modify its icon. N.B. You will"
+                                " need Xcode and its command-line tools"
+                                " installed to run this script successfully.")
 
     p.add_argument('-a', '--appname', action='store',
                    required=True,
@@ -243,14 +242,14 @@ def main():
         if args.icon_file.endswith('.png'):
             # Attempt to convert png to icns
             print "Converting .png file to .icns..."
-            args.icon_file = convert_to_icns(args.icon_file, verbose=args.verbose)
+            args.icon_file = convert_to_icns(args.icon_file,
+                                             verbose=args.verbose)
         print "Replacing icons with %s..." % args.icon_file
         for dest in [join(tmp_dir,
                             '%s/Managed Software Center.icns' % APP_DIRS['MSC_DIR']),
                         join(tmp_dir,
                             '%s/MunkiStatus.icns' % APP_DIRS['MS_DIR'])]:
             copyfile(args.icon_file, dest)
-
 
     if args.postinstall:
         # Copy postinstall to correct destination

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -175,6 +175,8 @@ def main():
                    default=None,
                    help="Use local copy of munki code. Specify path "
                    "e.g. '/Users/Shared/munkicode'.")
+    p.add_argument('-d', '--dep', action='store_true',
+                   help="Use make_munki_mpkg_DEP.sh vs make_munki_mpkg.sh")
     p.add_argument('-v', '--verbose', action='store_true',
                    help="Be more verbose.")
     args = p.parse_args()
@@ -257,7 +259,11 @@ def main():
         st = stat(dest)
         chmod(dest, (st.st_mode | 0111))
 
-    MUNKI_MAKESCRIPT = 'code/tools/make_munki_mpkg.sh'
+    if args.dep:
+        print 'Using DEP Package tool...'
+        MUNKI_MAKESCRIPT = 'code/tools/make_munki_mpkg_DEP.sh'
+    else:
+        MUNKI_MAKESCRIPT = 'code/tools/make_munki_mpkg.sh'
 
     # Run the munki build script on the customized files
     print "Building customized Munki..."


### PR DESCRIPTION
Adds the following capabilities:
- Use local munki code
- Use DEP packaging tool vs normal packaging tool.

```To use a local copy of munki use the ```--local-code``` option and specify a path. This will skip the git clone entirely.

To use the new DEP package tool, use the ```--dep``` option.
```

Fixes https://github.com/ox-it/munki-rebrand/issues/8