### PR TITLE
Add -s/--sign-package option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The ```--local-code``` option can be specified with a path to a directory contai
 
 The ```--dep``` option uses the new ```make_munki_mpkg_DEP.sh``` script which builds munki for use with DEP and other situations where you do not wish to force a reboot after install.
 
+The ```--sign-package``` option uses the new ```-s``` option from either ```make_munki_mpkg.sh``` or ```make_munki_mpkg_DEP.sh```. This allows you to have a rebranced munki package that is also natively signed. To use this option, your Developer Installer Certificate must be installed into the keychain. When using this option, you must specify the entire ```Common Name``` of the certificate. Example: ```"Developer ID Installer: Munki (U8PN57A5N2)"```
+
 For usage help please see ```sudo ./munki_rebrand.py --help```
 
 ## Notes
@@ -26,4 +28,3 @@ For usage help please see ```sudo ./munki_rebrand.py --help```
 ## To-do
 * Enable the splitting of the distribution pkg into its component pkgs so that the user can decide which to upgrade (perhaps they do not want to upgrade the launchd package if not necessary and can therefore avoid a reboot).
 * munkiimport the resulting pkg(s)?
-

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -188,7 +188,7 @@ def main():
                    "e.g. 'v2.8.2'. Leave blank for latest Github code")
     p.add_argument('-s', '--sign-package', action='store',
                    default=None,
-                   help="Optional tag to sign distribution package with a "
+                   help="Optional sign the munki distribution package with a "
                    "Developer ID Installer certificate from keychain. Provide "
                    "the certificate's Common Name. Ex: "
                    "'Developer ID Installer: Munki (U8PN57A5N2)'")

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -186,6 +186,12 @@ def main():
                    default=None,
                    help="Optional tag to download a specific release of munki "
                    "e.g. 'v2.8.2'. Leave blank for latest Github code")
+    p.add_argument('-s', '--sign-package', action='store',
+                   default=None,
+                   help="Optional tag to sign distribution package with a "
+                   "Developer ID Installer certificate from keychain. Provide "
+                   "the certificate's Common Name. Ex: "
+                   "'Developer ID Installer: Munki (U8PN57A5N2)'")
     p.add_argument('-v', '--verbose', action='store_true',
                    help="Be more verbose")
     args = p.parse_args()
@@ -286,9 +292,16 @@ def main():
     else:
         makescript = MUNKI_MAKESCRIPT
 
-    cmd = [join(tmp_dir, makescript),
-           '-r', tmp_dir,
-           '-o', tmp_dir]
+    # Run the makescript with -s if optionally passed
+    if not args.sign_package:
+        cmd = [join(tmp_dir, makescript),
+               '-r', tmp_dir,
+               '-o', tmp_dir]
+    else:
+        cmd = [join(tmp_dir, makescript),
+               '-r', tmp_dir,
+               '-s', args.sign_package,
+               '-o', tmp_dir]
     group = run_cmd(
         cmd,
         retgrep='Distribution.*(?P<munki_pkg>munkitools.*pkg).',


### PR DESCRIPTION
I noticed you had a `CodeSigning` branch but it was never merged.

Today I worked on a feature to use the munki scripts to sign the package: https://github.com/munki/munki/commit/66e50058c5e618654df7e4df2b1cfff169331dec

Now that this is officially merged, I added a -s/--sign-package option into your tool to use this process. I think this is a better approach overall.

For this PR I tried to follow your syntax/linting and overall coding style. My hope is this can be merged without any modifications like last time.