### PR TITLE
Find xcassets without hardcoding the path

### DIFF
--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -327,11 +327,11 @@ def convert_to_icns(png, output_dir, actool=""):
     # to provide the AppIcon
     if actool:
         # Use context of the location of munki_rebrand.py to find the Assets.xcassets directory.
-        rebrand_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
+        rebrand_dir = os.path.dirname(os.path.abspath(__file__))
         xc_assets_dir = os.path.join(rebrand_dir, 'Assets.xcassets/')
         if not os.path.isdir(xc_assets_dir):
-            print(f"The Assets.xcassets folder could not be found in {rebrand_dir}.\nMake sure it's in place, and then try again.")
-            exit(1)
+            print("The Assets.xcassets folder could not be found in %s.\nMake sure it's in place, and then try again." % rebrand_dir)
+            sys.exit(1)
         shutil.copytree(xc_assets_dir, xcassets, dirs_exist_ok=True)
         with io.open(os.path.join(iconset, "Contents.json"), "w") as f:
             contentstring = json.dumps(contents)

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -326,7 +326,13 @@ def convert_to_icns(png, output_dir, actool=""):
     # Munki 3.6+ has an Assets.car which is compiled from the Assets.xcassets
     # to provide the AppIcon
     if actool:
-        shutil.copytree("./Assets.xcassets/", xcassets, dirs_exist_ok=True)
+        # Use context of the location of munki_rebrand.py to find the Assets.xcassets directory.
+        rebrand_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
+        xc_assets_dir = os.path.join(rebrand_dir, 'Assets.xcassets/')
+        if not os.path.isdir(xc_assets_dir):
+            print(f"The Assets.xcassets folder could not be found in {rebrand_dir}.\nMake sure it's in place, and then try again.")
+            exit(1)
+        shutil.copytree(xc_assets_dir, xcassets, dirs_exist_ok=True)
         with io.open(os.path.join(iconset, "Contents.json"), "w") as f:
             contentstring = json.dumps(contents)
             f.write(contentstring)


### PR DESCRIPTION
It seems to be relatively common that people don't run `munki-rebrand.py` from the munki-rebrand directory itself. With the update to 4.0, rebrand relies on `munki-rebrand.py` being run from within the rebrand directory, because the location of the .xcassets folder is hardcoded to be relative to the $PWD variable. As a result, running rebrand from outside of the rebrand directory is not possible.

This PR fixes this behaviour - we dynamically get the location of the Python script itself, and then look in the same directory for the .xcassets folder. If it doesn't exist, we provide an error and exit. If it exists, we proceed.

I've tested this with Munki 5.3.0, and it seems to work fine. I didn't increment the version number (I figured that's best left up to you).