### PR TITLE
Python signing and minor updates

### DIFF
--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -449,7 +449,7 @@ def main():
         default=None,
         help="Optionally sign the munki app binaries with a "
         "Developer ID Application certificate from keychain. "
-        "Provide the certirficate's Common Name. Ex: "
+        "Provide the certificate's Common Name. Ex: "
         "'Developer ID Application  Munki (U8PN57A5N2)'",
     ),
     p.add_argument(

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -534,7 +534,7 @@ def sign_file(file_path, signing_id):
 
 def set_payload_perms(payload):
     """ Set root:admin throughout payload, passed to payload """
-    for root, dirs, files in os.walk(app_payload):
+    for root, dirs, files in os.walk(payload):
         for dir_ in dirs:
             os.chown(os.path.join(root, dir_), 0, 80)
         for file_ in files:

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -532,6 +532,13 @@ def sign_file(file_path, signing_id):
     ]
     run_cmd(cmd)
 
+def set_payload_perms(payload):
+    """ Set root:admin throughout payload, passed to payload """
+	for root, dirs, files in os.walk(app_payload):
+		for dir_ in dirs:
+			os.chown(os.path.join(root, dir_), 0, 80)
+		for file_ in files:
+			os.chown(os.path.join(root, file_), 0, 80)
 
 def main():
     p = argparse.ArgumentParser(
@@ -785,19 +792,8 @@ def main():
 				python_pkg_scripts,
 				python_output_pkg,
             )
-            # Set root:admin throughout payload
-            for root, dirs, files in os.walk(python_payload):
-                for dir_ in dirs:
-                    os.chown(os.path.join(root, dir_), 0, 80)
-                for file_ in files:
-                    os.chown(os.path.join(root, file_), 0, 80)
-
-        # Set root:admin throughout payload
-        for root, dirs, files in os.walk(app_payload):
-            for dir_ in dirs:
-                os.chown(os.path.join(root, dir_), 0, 80)
-            for file_ in files:
-                os.chown(os.path.join(root, file_), 0, 80)
+            set_payload_perms(python_payload)
+        set_payload_perms(app_payload)
         component_plist = os.path.join(tmp_dir, "component.plist")
         analyze(app_payload, component_plist)
         make_unrelocatable(component_plist)

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -500,6 +500,10 @@ def main():
         else:
             print("ERROR: icon file must be a 1024x1024 .png")
             sys.exit(1)
+    else:
+        print(f"ERROR: cannot find icon file {args.icon_file}")
+        sys.exit(1)
+
 
     output = os.path.join(tmp_dir, "munkitools.pkg")
 

--- a/munki_rebrand.py
+++ b/munki_rebrand.py
@@ -534,11 +534,11 @@ def sign_file(file_path, signing_id):
 
 def set_payload_perms(payload):
     """ Set root:admin throughout payload, passed to payload """
-	for root, dirs, files in os.walk(app_payload):
-		for dir_ in dirs:
-			os.chown(os.path.join(root, dir_), 0, 80)
-		for file_ in files:
-			os.chown(os.path.join(root, file_), 0, 80)
+    for root, dirs, files in os.walk(app_payload):
+        for dir_ in dirs:
+            os.chown(os.path.join(root, dir_), 0, 80)
+        for file_ in files:
+            os.chown(os.path.join(root, file_), 0, 80)
 
 def main():
     p = argparse.ArgumentParser(
@@ -785,12 +785,12 @@ def main():
             shutil.rmtree(python_pkg)
             python_output_pkg = os.path.join(newroot, os.path.basename(python_pkg))
             pkgbuild(
-				python_payload,
-				python_component_plist,
-				"com.googlecode.munki.python",
-				python_pkg_version,
-				python_pkg_scripts,
-				python_output_pkg,
+                python_payload,
+                python_component_plist,
+                "com.googlecode.munki.python",
+                python_pkg_version,
+                python_pkg_scripts,
+                python_output_pkg,
             )
             set_payload_perms(python_payload)
         set_payload_perms(app_payload)


### PR DESCRIPTION
As mentioned in the #munki-rebrand slack, this PR has 3 commits atm.. and they address:

1. https://github.com/ox-it/munki-rebrand/commit/f1e9c73ab4b70d57871469b01d4c9d7a6d836641 - Corrected --sign-binaries description
2. https://github.com/ox-it/munki-rebrand/commit/e9b39d11db637e1862b666c107a179727ca56183 -  Added error when icon file is declared but cannot be found, without this we hit an issue later on
3. https://github.com/ox-it/munki-rebrand/commit/733980cd96593153045e2e5cd0a22dc02e860f29 - Added support sign munki's python. Right now, this is enabled by the --sign-binaries flag, can move if wanted.

Next I'll likely refactor things some more and pylint.